### PR TITLE
Be explicit about rack version dependency

### DIFF
--- a/syro.gemspec
+++ b/syro.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
 
   s.add_dependency "seg"
-  s.add_dependency "rack"
+  s.add_dependency "rack", "~> 1.6.0"
   s.add_development_dependency "cutest"
   s.add_development_dependency "rack-test"
 end


### PR DESCRIPTION
While `.gems` list Rack 1.6.0 as dependency, gemspec was allowing
any version of rack to be valid and supported.

Since Syro uses Rack HTTP constants, must depend on Rack 1.6.0 or
greater.

Any other version of Rack will not support things like
`Rack::CONTENT_LENGTH`

Thank you
:heart: :heart: :heart: 
