### PR TITLE
Replace `attr` with `attr_reader`

### DIFF
--- a/lib/syro.rb
+++ b/lib/syro.rb
@@ -48,14 +48,14 @@ class Syro
     #     res.body
     #     # => ["there is", "no try"]
     #
-    attr :body
+    attr_reader :body
 
     # Returns a hash with the response headers.
     #
     #     res.headers
     #     # => { "Content-Type" => "text/html", "Content-Length" => "42" }
     #
-    attr :headers
+    attr_reader :headers
 
     def initialize(headers = {})
       @status  = nil


### PR DESCRIPTION
`attr_reader` is more common and states its intend clearly. `attr` has a weird signature being able to both create attribute readers as well as a single attribute accessor. In my opinion, `attr` has no advantage over `attr_reader` – and it's easy to read and well understood among Rubyists.
