### PR TITLE
Add possibility to test syro with Rack 2.0 alpha/beta

### DIFF
--- a/syro.gemspec
+++ b/syro.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
 
   s.add_dependency "seg"
-  s.add_dependency "rack", "~> 1.6.0"
+  s.add_dependency "rack", ">= 1.6.0", "< 2.0.0"
   s.add_development_dependency "cutest"
   s.add_development_dependency "rack-test"
 end


### PR DESCRIPTION
This adds the possibility to test Syro and frameworks
with Rack 2.0.0.alpha if it's installed.

It keeps installing Rack 1.6.x (stable) by default, so this
shouldn't break anything.

Ref: http://zzak.io/log/2016-04-18-the-road-to-sinatra-2.0.html
