### PR TITLE
Add failing test for nested path (on "bar/baz")

### DIFF
--- a/test/all.rb
+++ b/test/all.rb
@@ -209,6 +209,10 @@ test "path + verb" do |f|
   assert_equal 200, f.last_response.status
   assert_equal "GET /foo/bar", f.last_response.body
 
+  f.get("/bar/baz")
+  assert_equal 200, f.last_response.status
+  assert_equal "GET /bar/baz", f.last_response.body
+
   f.put("/foo/bar")
   assert_equal 200, f.last_response.status
   assert_equal "PUT /foo/bar", f.last_response.body


### PR DESCRIPTION
It looks like `on "bar/baz" do …` does not work as expected. This adds a failing test about that.
