### PR TITLE
Fix middleware example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ just use `Rack::Builder`:
 App = Rack::Builder.new do
   use Rack::Session::Cookie, secret: "..."
 
-  run Syro.new do
+  run Syro.new {
     get do
       res.write("Hello, world")
     end
-  end
+  }
 end
 ```
 


### PR DESCRIPTION
This PR fixes ambiguous block declaration on middleware example documentation, to avoid that when a `Syro#new` block is given it will be evaluated as `Rack::Builder#run` method block.