### PR TITLE
Improve performance by running the app block as a method

### DIFF
--- a/test/all.rb
+++ b/test/all.rb
@@ -117,6 +117,10 @@ script_name = Syro.new do
   end
 end
 
+exception = Syro.new do
+  get { res.text(this_method_does_not_exist) }
+end
+
 app = Syro.new do
   get do
     res.write "GET /"
@@ -259,6 +263,10 @@ app = Syro.new do
 
   on "script" do
     run(script_name)
+  end
+
+  on "exception" do
+    run(exception)
   end
 end
 
@@ -442,4 +450,12 @@ test "script name and path info" do |f|
   f.get("/script/path")
   assert_equal 200, f.last_response.status
   assert_equal "/script/path", f.last_response.body
+end
+
+test "deck exceptions reference a named class" do |f|
+  f.get("/exception")
+rescue NameError => exception
+  exception
+ensure
+  assert exception.to_s.include?("Syro::Deck")
 end


### PR DESCRIPTION
As discussed in #30, this PR makes Syro faster by running `@syro_code` as a method instead of via `instance_eval`. This PR should be backward-compatible, except for the one improbable edge case that arose in the linked discussion.

@soveran I've implemented all the changes we discussed, as well as two other changes:

1) I added a test to ensure Deck#inspect returns a useful class name.
2) As the name for the method that defines `#syro_dispatch!`, I used `::syro_implement` instead of `implement`. I don't think this name reads as well, but it is less likely to collide with an existing Deck whose author has written an `::implement` method. Please let me know if you'd like me to use `::implement` instead, or if there's anything else you'd like changed.

As for just how much faster Syro will get, it depends on how you measure. I'm seeing results that are 1.2x - 1.4x faster in Jeremy Evans' [r10k benchmark](https://github.com/jeremyevans/r10k), and 1.04x faster in Luis Lavena's IO-bound [bench-micro](https://github.com/luislavena/bench-micro). What I'm seeing in my current real-world application looks much closer to bench-micro.

Not that it matters much, given how close all the top contenders are to the performance of raw Rack, but at least according to bench-micro, Syro is now the fastest framework in the Ruby ecosystem. Jeremy has been working to speed up Roda using the same approach I took here — his approach is what made me curious to try it in Syro — so the results may change soon. But for now, glory.